### PR TITLE
🔧 chore(config): adjust MAX_THINKING_TOKENS to model output limit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -248,11 +248,11 @@
     ]
   },
   "env": {
+     "MAX_THINKING_TOKENS": "31999",
     "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
     "DISABLE_COST_WARNINGS": "0",
     "BASH_DEFAULT_TIMEOUT_MS": "300000",
     "BASH_MAX_TIMEOUT_MS": "1200000",
-    "MAX_THINKING_TOKENS": "200000",
     "UV_CACHE_DIR": "~/.cache/uv",
     "UV_PYTHON_PREFERENCE": "managed",
     "NODE_OPTIONS": "--max-old-space-size=4096"


### PR DESCRIPTION
## 📋 Description
Adjusted the `MAX_THINKING_TOKENS` configuration in `.claude/settings.json` from 200,000 to 31,999 to align with Claude Opus 4's token output limitations and prevent usage limit errors.

### 🎯 Related Issue
N/A - Configuration optimization

### 🔄 Type of Change
- [x] 🔧 Configuration (changes to settings, environment variables, etc.)

### 📝 Changes Made
- Reduced `MAX_THINKING_TOKENS` from 200,000 to 31,999 in `.claude/settings.json`

### 🧪 Test Evidence
```bash
# No tests required for configuration change
# Verified that Claude Code starts correctly with new setting
```

### 📚 Reasoning
- Claude Opus 4 has a 32,000 token output limit
- Claude Code automatically adds +1 to the configured value when setting the API's max_tokens parameter
- Setting values above the model's output limit causes:
  - Initial API call errors
  - Disabled streaming response functionality
  - Potential timeout issues
- The adjustment ensures smooth operation while preventing rapid token consumption

### ✅ Other Checklist
- [x] Documentation is updated (if applicable)
- [x] Changes follow existing patterns
- [x] No breaking changes introduced
- [x] Configuration values are properly validated

### 🤖 Additional Context
This change optimizes Claude Code's token usage to prevent hitting usage limits while maintaining sufficient thinking capacity for complex tasks.