### PR TITLE
🐛 fix(config): remove UV_CACHE_DIR to prevent tilde directory creation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -253,7 +253,6 @@
     "DISABLE_COST_WARNINGS": "0",
     "BASH_DEFAULT_TIMEOUT_MS": "300000",
     "BASH_MAX_TIMEOUT_MS": "1200000",
-    "UV_CACHE_DIR": "~/.cache/uv",
     "UV_PYTHON_PREFERENCE": "managed",
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1"

--- a/biome.json
+++ b/biome.json
@@ -132,8 +132,7 @@
       "!**/*.min.js",
       "!**/*.generated.*",
       "!**/migrations/*.sql",
-      "!.claude/**",
-      "!~/**"
+      "!.claude/**"
     ]
   },
   "overrides": [


### PR DESCRIPTION
## 📋 Description

Fixed an issue where serena MCP server was creating a literal "~" directory in the project root due to incorrect handling of the UV_CACHE_DIR environment variable.

### 🎯 Problem
- When using `claude mcp add serena`, a literal "~" directory was created in the project root
- This was caused by `UV_CACHE_DIR=~/.cache/uv` not being expanded properly by uvx
- The tilde (~) was interpreted literally instead of being expanded to the home directory

### 💡 Solution
- Removed `UV_CACHE_DIR` from `.claude/settings.json` to let uvx use its default behavior
- Removed the `\!~/**` pattern from `biome.json` ignore list as it's no longer needed

### 🔍 Root Cause Analysis
The issue occurred because:
1. UV_CACHE_DIR was set to `~/.cache/uv` in the environment
2. When uvx (Python execution environment) reads this variable, it doesn't perform shell expansion
3. This resulted in creating a literal "~" directory with `.cache/uv` subdirectories inside the project

### ✅ Checklist
- [x] Code follows project style guidelines
- [x] Configuration has been tested locally
- [x] No security vulnerabilities introduced
- [x] Documentation updated if needed

### 📸 Evidence
After the fix, running `claude mcp add serena` no longer creates the unwanted "~" directory in the project root.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>